### PR TITLE
Improves support for pandoc conversion of readme.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ output/
 boilerplate/
 *.bak
 pyro
+*.msi

--- a/{{cookiecutter.project_slug.lower().replace(' ','_').replace('-','_')}}/.travis.yml
+++ b/{{cookiecutter.project_slug.lower().replace(' ','_').replace('-','_')}}/.travis.yml
@@ -18,10 +18,6 @@ env:
     - TOXENV={{ env }}-nocov
 {%- endif %}
 {%- endfor %}
-addons:
-  apt:
-    packages:
-      - pandoc
 before_install:
   - python --version
   - uname -a
@@ -49,6 +45,9 @@ notifications:
 {%- if cookiecutter.pypi_deploy_with_travis == 'yes' %}
 # After you create the Github repo and add it to Travis, run the
 # ci/travis_pypi_setup.py script to finish PyPI deployment setup
+before_deploy:
+  - pip install pypandoc>=1.2.0
+  - python -c "import pypandoc; pypandoc.pandoc_download.download_pandoc()"
 deploy:
   provider: pypi
   distributions: sdist bdist_wheel
@@ -58,5 +57,5 @@ deploy:
   on:
     tags: true
     repo: {{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}
-    condition: $TOXENV == py27
+    condition: '"$TOXENV" == *"py"*'
 {%- endif %}

--- a/{{cookiecutter.project_slug.lower().replace(' ','_').replace('-','_')}}/ci/appveyor-bootstrap.py
+++ b/{{cookiecutter.project_slug.lower().replace(' ','_').replace('-','_')}}/ci/appveyor-bootstrap.py
@@ -108,6 +108,16 @@ def install_packages(home, *packages):
 
 
 if __name__ == "__main__":
-    install_python(environ['PYTHON_VERSION'], environ['PYTHON_ARCH'], environ['PYTHON_HOME'])
+    install_python(
+        environ['PYTHON_VERSION'],
+        environ['PYTHON_ARCH'],
+        environ['PYTHON_HOME']
+    )
     install_pip(environ['PYTHON_HOME'])
-    install_packages(environ['PYTHON_HOME'], "setuptools>=18.0.1", "wheel", "tox", "virtualenv>=13.1.0", "pypandoc==1.1.3")
+    install_packages(
+        environ['PYTHON_HOME'],
+        "setuptools>=18.0.1",
+        "wheel",
+        "tox",
+        "virtualenv>=13.1.0"
+    )

--- a/{{cookiecutter.project_slug.lower().replace(' ','_').replace('-','_')}}/ci/templates/.travis.yml
+++ b/{{cookiecutter.project_slug.lower().replace(' ','_').replace('-','_')}}/ci/templates/.travis.yml
@@ -40,10 +40,6 @@ env:
 {% endfor %}
 {%- endraw %}
 {% endif %}
-addons:
-  apt:
-    packages:
-      - pandoc
 before_install:
   - python --version
   - uname -a
@@ -71,6 +67,9 @@ notifications:
 {%- if cookiecutter.pypi_deploy_with_travis == 'yes' %}
 # After you create the Github repo and add it to Travis, run the
 # ci/travis_pypi_setup.py script to finish PyPI deployment setup
+before_deploy:
+  - pip install pypandoc>=1.2.0
+  - python -c "import pypandoc; pypandoc.pandoc_download.download_pandoc()"
 deploy:
   provider: pypi
   distributions: sdist bdist_wheel
@@ -80,5 +79,5 @@ deploy:
   on:
     tags: true
     repo: {{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}
-    condition: $TOXENV == py27
+    condition: '"$TOXENV" == *"py"*'
 {%- endif %}

--- a/{{cookiecutter.project_slug.lower().replace(' ','_').replace('-','_')}}/setup.py
+++ b/{{cookiecutter.project_slug.lower().replace(' ','_').replace('-','_')}}/setup.py
@@ -91,9 +91,10 @@ try:
         'rst',
         format='md')
     long_description = long_description.replace('\r\n', '\n')
-except (ImportError):
+except (ImportError, OSError):
     # pandoc is not installed, fallback to using raw contents
-    print("Pandoc not found. Long_description conversion failure.")
+    print("WARNING: Pandoc not found. Long_description conversion failure. "
+          "Do not upload this package to pypi.")
     with io.open('README.md', encoding="utf-8") as f:
         long_description = f.read()
 

--- a/{{cookiecutter.project_slug.lower().replace(' ','_').replace('-','_')}}/tox.ini
+++ b/{{cookiecutter.project_slug.lower().replace(' ','_').replace('-','_')}}/tox.ini
@@ -44,7 +44,6 @@ passenv =
     *
 usedevelop = false
 deps =
-    pypandoc==1.1.3
 {%- if cookiecutter.test_runner|lower == "pytest" %}
     pytest
     pytest-travis-fold
@@ -93,7 +92,7 @@ commands =
 
 [testenv:check]
 deps =
-    pypandoc==1.1.3
+    pypandoc>=1.2.0
     docutils
     check-manifest
     flake8
@@ -102,6 +101,7 @@ deps =
     isort
 skip_install = true
 commands =
+    python -c "import pypandoc; pypandoc.pandoc_download.download_pandoc()"
     python setup.py check --strict --metadata --restructuredtext
     check-manifest {toxinidir}
     flake8 --jobs=1 src tests setup.py


### PR DESCRIPTION
-   Updates pypandoc to v1.2.0.
-   This patch uses a try/catch block to import pypandoc and convert readme.md to rst for pypi packaging.
-   ImportError means that `pypandoc` is not available on the system. OSError means that `pandoc` is not available. Neither is required, unless this build is being uploaded to pypi.
-   Updates the travis `deploy` configuration to install pypandoc and pandoc before building the package for pypi.
-   Removes unnecssary pypandoc installs from various matrixed builds.
